### PR TITLE
🐛 Bug - Package imports - Re-add types creation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Test
         run: pnpm test
 
+      - name: Types
+        run: pnpm types
+
   publish:
     name: Publish to NPM or Create Version PR
     needs: build
@@ -79,6 +82,9 @@ jobs:
 
       - name: Build
         run: pnpm build
+        
+      - name: Types
+        run: pnpm types
 
       - name: Create Release Pull Request
         id: changesets
@@ -129,6 +135,9 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+      - name: Types
+        run: pnpm types
 
       - name: Set snapshot version
         run: |


### PR DESCRIPTION
When attempting to include a preview of the sqlite-level module into TinaCMS and TinaCloud, it was found that the `SqliteLevel` symbol could not be included. Error is believed to be caused by a lack of type definitions.