### PR TITLE
bump better-sqlite3 to v12 for Node 24 prebuilt support

### DIFF
--- a/.changeset/node24-windows-fix.md
+++ b/.changeset/node24-windows-fix.md
@@ -1,0 +1,5 @@
+---
+"sqlite-level": patch
+---
+
+bump better-sqlite3 to v12 to fix Node 24 install on Windows

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sqlite-level",
   "description": "sqlite backed abstract-level database for Node.js",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "abstract-level": "^1.0.4",
-    "better-sqlite3": "^11.8.1",
+    "better-sqlite3": "^12.9.0",
     "module-error": "^1.0.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.0.4
         version: 1.0.4
       better-sqlite3:
-        specifier: ^11.8.1
-        version: 11.8.1
+        specifier: ^12.9.0
+        version: 12.9.0
       module-error:
         specifier: ^1.0.2
         version: 1.0.2
@@ -945,8 +945,9 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
-  better-sqlite3@11.8.1:
-    resolution: {integrity: sha512-9BxNaBkblMjhJW8sMRZxnxVTRgbRmssZW0Oxc1MPBTfiR+WW21e2Mk4qu8CzrcZb1LwPCnFsfDEzq+SNcBU8eg==}
+  better-sqlite3@12.9.0:
+    resolution: {integrity: sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -2028,6 +2029,7 @@ packages:
   prebuild-install@7.1.2:
     resolution: {integrity: sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prettier@2.8.8:
@@ -3487,7 +3489,7 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
-  better-sqlite3@11.8.1:
+  better-sqlite3@12.9.0:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.2


### PR DESCRIPTION
Ran into tinacms/tinacms#6686 on a fresh Windows + Node 24 setup. npm install tinacms stalls trying to compile better-sqlite3 natively because ^11.8.1 (resolves to 11.10.0) has no prebuilt binary for win32/x64 on ABI 137. Bumping to ^12.9.0 picks up the prebuilt and the install completes cleanly.

No API changes needed in the sqlite-level source. The `Database`, `prepare`, `exec`, and `iterate` calls are all identical in v12. The lockfile just points to the new resolution.

One thing worth flagging: `better-sqlite3@12` drops Node 18 support (requires 20+). Node 18 went EOL in April 2025 so it probably doesn't matter, but flagging it in case TinaCMS still has users on it.