### PR TITLE
chore: bump better-sqlite3 to ^12.10.0 for Node 24 prebuilt support

### DIFF
--- a/.changeset/better-sqlite3-v12-node24-prebuilts.md
+++ b/.changeset/better-sqlite3-v12-node24-prebuilts.md
@@ -1,0 +1,7 @@
+---
+"sqlite-level": minor
+---
+
+Bump `better-sqlite3` from `^11.8.1` to `^12.9.0` so consumers pick up Node-24 (`NODE_MODULE_VERSION 137`) prebuilt binaries. The `better-sqlite3` v11.x line tops out at Node 23 prebuilts (`node-v131`), so a fresh `npm install` on Node 24 falls back to `node-gyp rebuild` and fails without a local Python + C++ toolchain (see [tinacms/tinacms#6686](https://github.com/tinacms/tinacms/issues/6686)). `better-sqlite3@12` adds Node 24 to its build matrix and drops EOL Node 18 — no API changes affect `SqliteLevel`'s usage of `Database`, `prepare`, `exec`, or `iterate`.
+
+Picks up the work in [#25](https://github.com/tinacms/sqlite-level/pull/25) (closed unmerged), now rebased onto the post-ESM v2.0.0 main.

--- a/.changeset/better-sqlite3-v12-node24-prebuilts.md
+++ b/.changeset/better-sqlite3-v12-node24-prebuilts.md
@@ -4,4 +4,14 @@
 
 Bump `better-sqlite3` from `^11.8.1` to `^12.9.0` so consumers pick up Node-24 (`NODE_MODULE_VERSION 137`) prebuilt binaries. The `better-sqlite3` v11.x line tops out at Node 23 prebuilts (`node-v131`), so a fresh `npm install` on Node 24 falls back to `node-gyp rebuild` and fails without a local Python + C++ toolchain (see [tinacms/tinacms#6686](https://github.com/tinacms/tinacms/issues/6686)). `better-sqlite3@12` adds Node 24 to its build matrix and drops EOL Node 18 — no API changes affect `SqliteLevel`'s usage of `Database`, `prepare`, `exec`, or `iterate`.
 
+**Platform-support narrowing — please read if you're on Node 20 or 23:**
+
+This caret pin (`^12.9.0`) resolves to `better-sqlite3@12.10.0`, whose [release notes](https://github.com/WiseLibs/better-sqlite3/releases/tag/v12.10.0) call out: *"Add support for Node.js v26 prebuilds and remove EOL builds (Node.js v20, v23)"*. So the prebuild matrix is now **Node 22, 24, 25, 26** only. Consumers on:
+
+- **Node 20** (LTS — reached EOL 2026-04-30): install will fall back to `node-gyp rebuild` and require a local Python + C++ toolchain. Same failure mode this PR fixes for Node 24, just on a different Node major. Upgrading to Node 22 LTS is the recommended path.
+- **Node 23** (non-LTS, EOL 2025-06-01): same install failure.
+- **Node 18** (EOL 2025-04-30): unchanged — better-sqlite3 v12 dropped Node 18 in its `engines` field. Was already not picking up Node 18 prebuilds.
+
+Tina-first-party consumers (TinaCloud content-api, TinaCMS's `@tinacms/search`, the `tina-self-hosted-demo` example) all target Node 22+ and are unaffected.
+
 Picks up the work in [#25](https://github.com/tinacms/sqlite-level/pull/25) (closed unmerged), now rebased onto the post-ESM v2.0.0 main.

--- a/.changeset/better-sqlite3-v12-node24-prebuilts.md
+++ b/.changeset/better-sqlite3-v12-node24-prebuilts.md
@@ -2,11 +2,11 @@
 "sqlite-level": minor
 ---
 
-Bump `better-sqlite3` from `^11.8.1` to `^12.9.0` so consumers pick up Node-24 (`NODE_MODULE_VERSION 137`) prebuilt binaries. The `better-sqlite3` v11.x line tops out at Node 23 prebuilts (`node-v131`), so a fresh `npm install` on Node 24 falls back to `node-gyp rebuild` and fails without a local Python + C++ toolchain (see [tinacms/tinacms#6686](https://github.com/tinacms/tinacms/issues/6686)). `better-sqlite3@12` adds Node 24 to its build matrix and drops EOL Node 18 — no API changes affect `SqliteLevel`'s usage of `Database`, `prepare`, `exec`, or `iterate`.
+Bump `better-sqlite3` from `^11.8.1` to `^12.10.0` so consumers pick up Node-24 (`NODE_MODULE_VERSION 137`) prebuilt binaries. The `better-sqlite3` v11.x line tops out at Node 23 prebuilts (`node-v131`), so a fresh `npm install` on Node 24 falls back to `node-gyp rebuild` and fails without a local Python + C++ toolchain (see [tinacms/tinacms#6686](https://github.com/tinacms/tinacms/issues/6686)). `better-sqlite3@12` adds Node 24 to its build matrix and drops EOL Node 18 — no API changes affect `SqliteLevel`'s usage of `Database`, `prepare`, `exec`, or `iterate`.
 
 **Platform-support narrowing — please read if you're on Node 20 or 23:**
 
-This caret pin (`^12.9.0`) resolves to `better-sqlite3@12.10.0`, whose [release notes](https://github.com/WiseLibs/better-sqlite3/releases/tag/v12.10.0) call out: *"Add support for Node.js v26 prebuilds and remove EOL builds (Node.js v20, v23)"*. So the prebuild matrix is now **Node 22, 24, 25, 26** only. Consumers on:
+This caret pin (`^12.10.0`) resolves to `better-sqlite3@12.10.0`, whose [release notes](https://github.com/WiseLibs/better-sqlite3/releases/tag/v12.10.0) call out: *"Add support for Node.js v26 prebuilds and remove EOL builds (Node.js v20, v23)"*. So the prebuild matrix is now **Node 22, 24, 25, 26** only. Consumers on:
 
 - **Node 20** (LTS — reached EOL 2026-04-30): install will fall back to `node-gyp rebuild` and require a local Python + C++ toolchain. Same failure mode this PR fixes for Node 24, just on a different Node major. Upgrading to Node 22 LTS is the recommended path.
 - **Node 23** (non-LTS, EOL 2025-06-01): same install failure.

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "abstract-level": "^1.0.4",
-    "better-sqlite3": "^11.8.1",
+    "better-sqlite3": "^12.9.0",
     "module-error": "^1.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "abstract-level": "^1.0.4",
-    "better-sqlite3": "^12.9.0",
+    "better-sqlite3": "^12.10.0",
     "module-error": "^1.0.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.0.4
         version: 1.0.4
       better-sqlite3:
-        specifier: ^11.8.1
-        version: 11.8.1
+        specifier: ^12.9.0
+        version: 12.10.0
       module-error:
         specifier: ^1.0.2
         version: 1.0.2
@@ -291,51 +291,61 @@ packages:
     resolution: {integrity: sha512-PKvszb+9o/vVdUzCCjL0sKHukEQV39tD3fepXxYrHE3sTKrRdCydI7uldRLbjLmDA3TFDmh418XH19NOsDRH8g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.32.1':
     resolution: {integrity: sha512-9WHEMV6Y89eL606ReYowXuGF1Yb2vwfKWKdD1A5h+OYnPZSJvxbEjxTRKPgi7tkP2DSnW0YLab1ooy+i/FQp/Q==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.32.1':
     resolution: {integrity: sha512-tZWc9iEt5fGJ1CL2LRPw8OttkCBDs+D8D3oEM8mH8S1ICZCtFJhD7DZ3XMGM8kpqHvhGUTvNUYVDnmkj4BDXnw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.32.1':
     resolution: {integrity: sha512-FTYc2YoTWUsBz5GTTgGkRYYJ5NGJIi/rCY4oK/I8aKowx1ToXeoVVbIE4LGAjsauvlhjfl0MYacxClLld1VrOw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.32.1':
     resolution: {integrity: sha512-F51qLdOtpS6P1zJVRzYM0v6MrBNypyPEN1GfMiz0gPu9jN8ScGaEFIZQwteSsGKg799oR5EaP7+B2jHgL+d+Kw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.32.1':
     resolution: {integrity: sha512-wO0WkfSppfX4YFm5KhdCCpnpGbtgQNj/tgvYzrVYFKDpven8w2N6Gg5nB6w+wAMO3AIfSTWeTjfVe+uZ23zAlg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.32.1':
     resolution: {integrity: sha512-iWswS9cIXfJO1MFYtI/4jjlrGb/V58oMu4dYJIKnR5UIwbkzR0PJ09O0PDZT0oJ3LYWXBSWahNf/Mjo6i1E5/g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.32.1':
     resolution: {integrity: sha512-RKt8NI9tebzmEthMnfVgG3i/XeECkMPS+ibVZjZ6mNekpbbUmkNWuIN2yHsb/mBPyZke4nlI4YqIdFPgKuoyQQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.32.1':
     resolution: {integrity: sha512-WQFLZ9c42ECqEjwg/GHHsouij3pzLXkFdz0UxHa/0OM12LzvX7DzedlY0SIEly2v18YZLRhCRoHZDxbBSWoGYg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.32.1':
     resolution: {integrity: sha512-BLoiyHDOWoS3uccNSADMza6V6vCNiphi94tQlVIL5de+r6r/CCQuNnerf+1g2mnk2b6edp5dk0nhdZ7aEjOBsA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.32.1':
     resolution: {integrity: sha512-w2l3UnlgYTNNU+Z6wOR8YdaioqfEnwPjIsJ66KxKAf0p+AuL2FHeTX6qvM+p/Ue3XPBVNyVSfCrfZiQh7vZHLQ==}
@@ -453,8 +463,9 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
-  better-sqlite3@11.8.1:
-    resolution: {integrity: sha512-9BxNaBkblMjhJW8sMRZxnxVTRgbRmssZW0Oxc1MPBTfiR+WW21e2Mk4qu8CzrcZb1LwPCnFsfDEzq+SNcBU8eg==}
+  better-sqlite3@12.10.0:
+    resolution: {integrity: sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
@@ -832,6 +843,7 @@ packages:
   prebuild-install@7.1.2:
     resolution: {integrity: sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prettier@2.8.8:
@@ -1521,7 +1533,7 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
-  better-sqlite3@11.8.1:
+  better-sqlite3@12.10.0:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         specifier: ^1.0.4
         version: 1.0.4
       better-sqlite3:
-        specifier: ^12.9.0
+        specifier: ^12.10.0
         version: 12.10.0
       module-error:
         specifier: ^1.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,61 +291,51 @@ packages:
     resolution: {integrity: sha512-PKvszb+9o/vVdUzCCjL0sKHukEQV39tD3fepXxYrHE3sTKrRdCydI7uldRLbjLmDA3TFDmh418XH19NOsDRH8g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.32.1':
     resolution: {integrity: sha512-9WHEMV6Y89eL606ReYowXuGF1Yb2vwfKWKdD1A5h+OYnPZSJvxbEjxTRKPgi7tkP2DSnW0YLab1ooy+i/FQp/Q==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.32.1':
     resolution: {integrity: sha512-tZWc9iEt5fGJ1CL2LRPw8OttkCBDs+D8D3oEM8mH8S1ICZCtFJhD7DZ3XMGM8kpqHvhGUTvNUYVDnmkj4BDXnw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.32.1':
     resolution: {integrity: sha512-FTYc2YoTWUsBz5GTTgGkRYYJ5NGJIi/rCY4oK/I8aKowx1ToXeoVVbIE4LGAjsauvlhjfl0MYacxClLld1VrOw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.32.1':
     resolution: {integrity: sha512-F51qLdOtpS6P1zJVRzYM0v6MrBNypyPEN1GfMiz0gPu9jN8ScGaEFIZQwteSsGKg799oR5EaP7+B2jHgL+d+Kw==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.32.1':
     resolution: {integrity: sha512-wO0WkfSppfX4YFm5KhdCCpnpGbtgQNj/tgvYzrVYFKDpven8w2N6Gg5nB6w+wAMO3AIfSTWeTjfVe+uZ23zAlg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.32.1':
     resolution: {integrity: sha512-iWswS9cIXfJO1MFYtI/4jjlrGb/V58oMu4dYJIKnR5UIwbkzR0PJ09O0PDZT0oJ3LYWXBSWahNf/Mjo6i1E5/g==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.32.1':
     resolution: {integrity: sha512-RKt8NI9tebzmEthMnfVgG3i/XeECkMPS+ibVZjZ6mNekpbbUmkNWuIN2yHsb/mBPyZke4nlI4YqIdFPgKuoyQQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.32.1':
     resolution: {integrity: sha512-WQFLZ9c42ECqEjwg/GHHsouij3pzLXkFdz0UxHa/0OM12LzvX7DzedlY0SIEly2v18YZLRhCRoHZDxbBSWoGYg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.32.1':
     resolution: {integrity: sha512-BLoiyHDOWoS3uccNSADMza6V6vCNiphi94tQlVIL5de+r6r/CCQuNnerf+1g2mnk2b6edp5dk0nhdZ7aEjOBsA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.32.1':
     resolution: {integrity: sha512-w2l3UnlgYTNNU+Z6wOR8YdaioqfEnwPjIsJ66KxKAf0p+AuL2FHeTX6qvM+p/Ue3XPBVNyVSfCrfZiQh7vZHLQ==}
@@ -843,7 +833,6 @@ packages:
   prebuild-install@7.1.2:
     resolution: {integrity: sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==}
     engines: {node: '>=10'}
-    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prettier@2.8.8:


### PR DESCRIPTION
Resurrects #25 (closed unmerged on 2026-05-10) on top of the v2.0.0 ESM main.

## The problem

`better-sqlite3` v11.x prebuilt assets top out at `NODE_MODULE_VERSION 131` (Node **23**). Node 24 is ABI **137**. So on a fresh `npm/pnpm/yarn install` with Node 24:

```
prebuild-install warn install No prebuilt binaries found
  (target=24.x.x runtime=node arch=x64 libc= platform=...)
```

…and install falls back to `node-gyp rebuild`, which needs a local Python + a C++ toolchain (MSVC on Windows, Xcode CLT on macOS, build-essential on Linux). On a clean Windows dev box neither exists → install fails.

This is exactly the failure mode reported in [tinacms/tinacms#6686](https://github.com/tinacms/tinacms/issues/6686).

## The fix

`better-sqlite3@12.0.0` added Node 24 (`node-v137`) to its prebuild matrix and dropped EOL Node 18 — see [the v12.0.0 release notes](https://github.com/WiseLibs/better-sqlite3/releases/tag/v12.0.0). Pinning `^12.10.0` — the version this PR's lockfile actually resolves to and which CI verified passes tests + build. (#25 had used `^12.9.0`, inherited from what @galsakuri tested locally; `^12.10.0` is the honest "floor = what we shipped against" choice.)

No source-code changes needed in this package. `SqliteLevel`'s use of `Database`, `prepare`, `exec`, and `iterate` is unchanged between v11 and v12.

## ⚠️ Platform-support narrowing

`better-sqlite3@12.10.0`'s [release notes](https://github.com/WiseLibs/better-sqlite3/releases/tag/v12.10.0) call out: *"Add support for Node.js v26 prebuilds and **remove EOL builds (Node.js v20, v23)**"*. So the post-merge prebuild matrix is:

| Node version | EOL date | Prebuilt in `better-sqlite3@12.10.0`? |
|---|---|---|
| Node 18 | 2025-04-30 | ❌ (was already dropped in v12.0.0) |
| Node 20 LTS | 2026-04-30 (**18 days ago**) | ❌ |
| Node 21 | 2024-06-01 | ❌ |
| Node 22 LTS | 2027-04-30 | ✅ |
| Node 23 | 2025-06-01 | ❌ |
| Node 24 LTS | 2028-04-30 | ✅ (**the fix**) |
| Node 25 | 2026-06-01 | ✅ |
| Node 26 | (active) | ✅ |

In practice, every Node major that loses prebuild support here is **already EOL** by the Node.js release schedule. But it does mean: a consumer on Node 20 today, hitting install for the first time after a `sqlite-level` release from this PR, will see the same `node-gyp` fallback failure that Node 24 users currently hit. Their options are:

1. Upgrade to Node 22 LTS (recommended — Node 20 is EOL)
2. Install a local Python + C++ toolchain so `node-gyp rebuild` succeeds
3. Stay on the previous `sqlite-level` version

**Tina-first-party consumers** (`tina-content-api`, TinaCMS workspaces' build matrix `[22, 24, 25]`, `tina-self-hosted-demo`) all target Node 22+ and are unaffected. A coordinated `.nvmrc` bump from `v20` to `v22` in [tinacms/tinacms](https://github.com/tinacms/tinacms) is recommended alongside the consumption of the new `sqlite-level` release so the `publish.yml` workflow keeps installing cleanly — opened as [tinacms/tinacms#6905](https://github.com/tinacms/tinacms/pull/6905).

## Why the original PR was closed without merging

PR #25 was opened 2026-04-19, closed 2026-05-10 with no human comments. The ESM-migration v2.0.0 release went out 4 days later (2026-05-14) without picking up this change, so `sqlite-level@2.0.0` still ships the v11 pin — meaning the Node 24 install failure has not been fixed on npm yet, despite #6686 being treated by downstream issues as "resolved by the v2 bump."

## Verification

- [x] `pnpm install` — clean. `better-sqlite3` resolves to **12.10.0**.
- [x] `pnpm install --frozen-lockfile` — clean.
- [x] `pnpm test` — **66 / 66 tests pass**.
- [x] `pnpm types` — clean.
- [x] `pnpm build` — clean (`tsc` exit 0).
- [x] Changeset added as **minor** (consumer-visible: prebuild matrix shifts; Node 18/20/23 dropped).

## Trade-off summary

| | Before this PR (`sqlite-level@2.0.0` → `better-sqlite3@11.x`) | After this PR (`sqlite-level@2.1.0` → `better-sqlite3@12.10.0`) |
|---|---|---|
| Node 24 (current LTS) install | ❌ Broken (#6686) | ✅ Works |
| Node 20 (EOL'd 2026-04-30) install | ✅ Works | ❌ Broken |
| Node 22 (LTS) install | ✅ Works | ✅ Works |

Net: trades install support for an EOL Node line in exchange for the current LTS.

## Downstream PRs blocked on this

- [tinacms/tinacms#6905](https://github.com/tinacms/tinacms/pull/6905) — bump tinacms's `.nvmrc` from v20 to v22 (Node 20 EOL)
- [tinacms/tinacms#6848](https://github.com/tinacms/tinacms/issues/6848) — bump `sqlite-level` in `@tinacms/search`'s catalog after this releases
- Tinacloud content-api will get a parallel direct-dep bump after this releases (replacing the earlier closed #3531)

🤖 Generated with [Claude Code](https://claude.com/claude-code)